### PR TITLE
Improve behavior of SID on high-error-rate connections

### DIFF
--- a/common/ud3core/tasks/tsk_eth.c
+++ b/common/ud3core/tasks/tsk_eth.c
@@ -113,7 +113,9 @@ void tsk_eth_TaskProc(void *pvParameters) {
     
     uint8_t flow_ctl[NUM_ETH_CON];
     uint16_t bytes_waiting[NUM_ETH_CON];
-    
+
+    uint8_t counter = 0;
+
     for(int i =0;i<NUM_ETH_CON;i++){
         synth_socket[i]=0xFF;
         cli_socket[i]=0xFF;
@@ -209,16 +211,18 @@ void tsk_eth_TaskProc(void *pvParameters) {
                             break;
                         case SYNTH_SID:
                             if(bytes_waiting[i]>1800){
-                                if(flow_ctl[i]){
+                                if(flow_ctl[i] || counter==0){
                                     ETH_TcpSend(synth_socket[i],&stop,1,0);
                                     flow_ctl[i]=0;
                                 }
                             }else{
-                                 if(!flow_ctl[i]){
+                                 if(!flow_ctl[i] || counter==0){
                                     flow_ctl[i]=1;
                                     ETH_TcpSend(synth_socket[i],&start,1,0);
                                 }
                             }
+                            ++counter;
+                            counter = counter%8;
                             if(uxQueueSpacesAvailable(qSID) > 15){
             				    len = ETH_TcpReceive(synth_socket[i],buffer,LOCAL_ETH_BUFFER_SIZE,0);
             				    if(len){

--- a/common/ud3core/tasks/tsk_midi.c
+++ b/common/ud3core/tasks/tsk_midi.c
@@ -314,9 +314,10 @@ CY_ISR(isr_sid) {
                 channel[i].old_gate = sid_frm.gate[i];
             }
         }else{
-            channel[0].volume = 0;
-            channel[1].volume = 0;
-            channel[2].volume = 0;
+            for (uint8_t i = 0;i<SID_CHANNELS;++i) {
+                channel[i].volume = 0;
+                channel[i].adsr_state = ADSR_IDLE;
+            }
         }
     }else{
         cnt++;


### PR DESCRIPTION
1. When the SID frame queue ran empty in the middle of a song before this PR the output would sometimes continue due to the current ADSR state.
2. If the `start`-packet got lost at any point TT would just stop sending data permanently. This happened very quickly in my testing, causing the first issue. With this PR both the `start` and `stop` packets are resend ever 16 ms, to ensure that it will arrive at some point.

With these changes I can play SID (dump) files on my DRSSTC without really noticing the bad connection, something that's completely impossible with MIDI. I also wrote [a small Python script](https://gist.github.com/malte0811/38c1810b8f1ed2238b3d4b6557ffa4de) to convert MIDI to SID dumps.