### PR TITLE
add temp2 setpoint with configurable behavior

### DIFF
--- a/common/ud3core/cli_common.c
+++ b/common/ud3core/cli_common.c
@@ -112,6 +112,8 @@ void init_config(){
     configuration.max_tr_duty = 100;
     configuration.max_qcw_duty = 350;
     configuration.temp1_setpoint = 30;
+    configuration.temp2_setpoint = 30;
+    configuration.temp2_mode = 0;
     configuration.ps_scheme = 2;
     configuration.autotune_s = 1;
     configuration.baudrate = 460800;
@@ -219,6 +221,8 @@ parameter_entry confparam[] = {
     ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"max_tr_duty"     , configuration.max_tr_duty     , 1      ,500    ,10     ,callback_ConfigFunction     ,"Max TR duty cycle [%]")
     ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"max_qcw_duty"    , configuration.max_qcw_duty    , 1      ,500    ,10     ,callback_ConfigFunction     ,"Max QCW duty cycle [%]")
     ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"temp1_setpoint"  , configuration.temp1_setpoint  , 0      ,100    ,0      ,NULL                        ,"Setpoint for fan [*C]")
+    ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"temp2_setpoint"  , configuration.temp2_setpoint  , 0      ,100    ,0      ,NULL                        ,"Setpoint for TH2 [*C] 0=disabled")
+    ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"temp2_mode"      , configuration.temp2_mode      , 0      ,4      ,0      ,NULL                        ,"TH2 setpoint mode  0=disabled 1=FAN 3=Relay3 4=Relay4")
     ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"ps_scheme"       , configuration.ps_scheme       , 0      ,5      ,0      ,callback_ConfigFunction     ,"Power supply scheme")
     ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"charge_delay"    , configuration.chargedelay     , 1      ,60000  ,0      ,callback_ConfigFunction     ,"Delay for the charge relay [ms]")  
     ADD_PARAM(PARAM_CONFIG  ,pdTRUE ,"autotune_s"      , configuration.autotune_s      , 1      ,32     ,0      ,NULL                        ,"Number of samples for Autotune")

--- a/common/ud3core/cli_common.h
+++ b/common/ud3core/cli_common.h
@@ -90,6 +90,8 @@ struct config_struct{
     uint16_t max_tr_duty;
     uint16_t max_qcw_duty;
     uint16_t temp1_setpoint;
+    uint16_t temp2_setpoint;
+    uint8_t temp2_mode;
     uint8_t ps_scheme;
     uint8_t autotune_s;
     char ud_name[16];

--- a/common/ud3core/tasks/tsk_cli.c
+++ b/common/ud3core/tasks/tsk_cli.c
@@ -163,6 +163,8 @@ static const char * AC_set_get[] = {
     "temp1_max",
     "temp1_setpoint",
     "temp2_max",
+    "temp2_setpoint",
+    "temp2_action",
     "transpose",
     "tune_delay",
     "tune_end",


### PR DESCRIPTION
This adds an additional setpoint for the second thermistor, and allows it to control FAN (in addition to th1, where either will turn the fan on, but both have to be cleared for the fan to turn off), or relay3/4.

This has been bench tested and seems to behave as intended. Default behavior is unchanged.

In my system I will have a thermistor on the heatsink and primary cooling water return, but both the heatsink and the radiator share a fan, so I want either thermistor to be able to turn the fan on.