### PR TITLE
A few misc bug fixes

### DIFF
--- a/common/ud3core/tasks/tsk_analog.c
+++ b/common/ud3core/tasks/tsk_analog.c
@@ -400,7 +400,7 @@ void ac_dual_meas_scheme(){
 }
 
 void ac_precharge_fixed_delay(){
-    if(relay_read_bus() && relay_read_charge_end()){
+    if(!relay_read_bus() && !relay_read_charge_end()){
         alarm_push(ALM_PRIO_INFO,warn_bus_charging, ALM_NO_VALUE);
         sysfault.charge=1;
         xTimerStart(xCharge_Timer,0);

--- a/common/ud3core/tasks/tsk_analog.c
+++ b/common/ud3core/tasks/tsk_analog.c
@@ -421,7 +421,7 @@ void vCharge_Timer_Callback(TimerHandle_t xTimer){
         }
     }else{
         relay_write_bus(0);
-        relay_read_charge_end(0);
+        relay_write_charge_end(0);
         sysfault.charge=0;
         alarm_push(ALM_PRIO_INFO,warn_bus_off, ALM_NO_VALUE);
         tt.n.bus_status.value = BUS_OFF;

--- a/common/ud3core/tasks/tsk_analog.h
+++ b/common/ud3core/tasks/tsk_analog.h
@@ -63,8 +63,8 @@ enum I2T {
 #define relay_write_bus(val) Relay1_Write(val)
 #define relay_write_charge_end(val) Relay2_Write(val)
 
-#define relay_read_bus(val) Relay1_Read()
-#define relay_read_charge_end(val) Relay2_Read()
+#define relay_read_bus() Relay1_Read()
+#define relay_read_charge_end() Relay2_Read()
 
 volatile uint8 bus_command;
 

--- a/common/ud3core/tasks/tsk_thermistor.c
+++ b/common/ud3core/tasks/tsk_thermistor.c
@@ -143,7 +143,9 @@ int32_t get_temp_128(int32_t counts) {
 
 int32_t get_temp_counts(uint8_t channel){
     Therm_Mux_Select(channel);
-    vTaskDelay(20);
+    vTaskDelay(50);     // DS: this used to delay just 20 ticks which wasn't long enough on my board.
+                        // The temps were all off by 10 degrees or so.  Once I changed this to 50 the 
+                        // temps were all within a degree of where they should be.
     ADC_therm_StartConvert();
     vTaskDelay(50);
     int16_t temp = ADC_therm_GetResult16()-ADC_therm_Offset;


### PR DESCRIPTION
- Bugfix: I noticed the charge_end relay never gets energized when ps_scheme is set to 5 (AC_PRECHARGE_FIXED_DELAY).  This was due to some inverted logic in the "if" statement.

- Bugfix: I connected a 10K resistor across therm1 and noticed in the status display that the displayed temperature was 33 degrees C instead of the expected 25.   I got into the debugger and single stepped through the code and then the temp was fine.  This lead me to discover that the delay after changing the thermistor multiplexor wasn't long enough.  The debugger slowed everything down so it would work.  To fix it I increased the delay from 20 to 50 ticks.

- Bugfix: the charge_timer callback was reading the charge_end relay status and then doing nothing with the read value.  I think the intention was to WRITE a 0 to the charge_end timer.  Passing a value to the charge_end READ function makes no sense so I removed the argument from the macro to prevent this kind of bug from happening in the future.

This is my first pull request.  Please let me know if I did anything wrong.  Thanks.