### PR TITLE
Simulator stuff and divide by 0 fix

### DIFF
--- a/common/ud3core/tasks/tsk_eth_common.c
+++ b/common/ud3core/tasks/tsk_eth_common.c
@@ -302,7 +302,7 @@ void process_min_sid(uint8_t* ptr, uint16_t len) {
             SID_frame.wave[i] = bit_is_set(*ptr, 7);
             SID_frame.gate[i] = bit_is_set(*ptr, 0);
             
-            if(filter.channel[i]==0 || freq_temp > filter.max || freq_temp < filter.min){
+            if(filter.channel[i]==0 || freq_temp > filter.max || freq_temp < filter.min || freq_temp == 0){
                 SID_frame.gate[i]=0;
             }
             if(SID_frame.wave[i] && filter.noise_disable){

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -65,7 +65,7 @@ SOURCE_FILES += $(wildcard ${CORE_DIR}/vms/*.c)
 
 
 CFLAGS := -ggdb3 -Os -DprojCOVERAGE_TEST=0 -std=gnu11
-LDFLAGS := -ggdb3 -Os -pthread -lpcap -lm
+LDFLAGS := -ggdb3 -Os -pthread -lpcap -lm -zmuldefs
 
 OBJ_FILES = $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.o)
 

--- a/simulator/sim_hw.h
+++ b/simulator/sim_hw.h
@@ -108,6 +108,10 @@ uint8_t no_fb_reg_Read();
 #define Comp_1_Start()
 #define ADC_Start()
 
+#define temp_pwm_WriteCompare1(compare)
+#define temp_pwm_WriteCompare2(compare)
+#define temp_pwm_Start()
+
 #define Disp_GREEN 0
 #define Disp_RED 0
 #define Disp_BLUE 0
@@ -115,6 +119,9 @@ uint8_t no_fb_reg_Read();
 #define Disp_BLACK 0
 #define Disp_OCEAN 0
 #define Disp_ORANGE 0
+#define Disp_CYAN 0
+#define Disp_MAGENTA 0
+#define Disp_YELLOW 0
 
 #define Disp_MemClear(p1)
 #define Disp_DrawRect(p1,p2,p3,p4,p5,p6)


### PR DESCRIPTION
- Simulator now provides a serial port (pseudo terminal) in addition to the UDP socket
  - Can someone test that this works on Windows? I don't even know how you run the sim there.
- Fix sim compile issues
  - Some due to recent commits, one due to (I assume) different linker versions
- Simulated bus voltage now drops all the way to 0 when bus is turned off
  - Not relevant for anything, but it annoyed me
- Some SID files (e.g. `Mortal_Kombat.sid`) sometimes enable a channel, but set the frequency to 0
  - I have no idea what this does on a hardware UD3, but it crashed the simulator for me
  - Fixed by disabling any channels with frequency 0