### PR TITLE
Fixes for tterm and code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ ComponentUpdateLog.txt
 *.cyprj.*
 *.cywrk.*
 *.v2
+simulator/build
+simulator/eeprom.txt

--- a/common/tterm/TTerm.c
+++ b/common/tterm/TTerm.c
@@ -82,6 +82,7 @@ TERMINAL_HANDLE * TERM_createNewHandle(TermPrintHandler printFunction, unsigned 
         
         TERM_addCommand(CMD_help, "help", "Displays this help message", 0, &TERM_cmdListHead);
         TERM_addCommand(CMD_cls, "cls", "Clears the screen", 0, &TERM_cmdListHead);
+        TERM_addCommand(CMD_testCommandHandler, "test", "Test input", 0, &TERM_cmdListHead);
         //TERM_addCommand(CMD_reset, "reset", "resets the fibernet", 0, &TERM_cmdListHead);
         
         REGISTER_apps(&TERM_cmdListHead);
@@ -662,7 +663,7 @@ uint8_t TERM_interpretCMD(char * data, uint16_t dataLength, TERMINAL_HANDLE * ha
     return TERM_CMD_EXIT_NOT_FOUND;
 }
 
-uint8_t TERM_seperateArgs(char * data, uint16_t dataLength, char ** buff){
+uint16_t TERM_seperateArgs(char * data, uint16_t dataLength, char ** buff){
     uint8_t count = 0;
     uint8_t currPos = 0;
     unsigned quoteMark = 0;
@@ -701,7 +702,7 @@ uint8_t TERM_seperateArgs(char * data, uint16_t dataLength, char ** buff){
                 break;
         }
     }
-    if(quoteMark) TERM_ARGS_ERROR_STRING_LITERAL;
+    if(quoteMark) return TERM_ARGS_ERROR_STRING_LITERAL;
     return count;
 }
 
@@ -744,7 +745,7 @@ uint16_t TERM_countArgs(const char * data, uint16_t dataLength){
                 break;
         }
     }
-    if(quoteMark) TERM_ARGS_ERROR_STRING_LITERAL;
+    if(quoteMark) return TERM_ARGS_ERROR_STRING_LITERAL;
     return count;
 }
 

--- a/common/tterm/TTerm.h
+++ b/common/tterm/TTerm.h
@@ -251,7 +251,7 @@ void TERM_sendVT100Code(TERMINAL_HANDLE * handle, uint16_t cmd, uint8_t var);
 const char * TERM_getVT100Code(uint16_t cmd, uint8_t var);
 uint16_t TERM_countArgs(const char * data, uint16_t dataLength);
 uint8_t TERM_interpretCMD(char * data, uint16_t dataLength, TERMINAL_HANDLE * handle);
-uint8_t TERM_seperateArgs(char * data, uint16_t dataLength, char ** buff);
+uint16_t TERM_seperateArgs(char * data, uint16_t dataLength, char ** buff);
 void TERM_checkForCopy(TERMINAL_HANDLE * handle, COPYCHECK_MODE mode);
 void TERM_printDebug(TERMINAL_HANDLE * handle, char * format, ...);
 void TERM_removeProgramm(TERMINAL_HANDLE * handle);

--- a/common/vms/ADSREngine.c
+++ b/common/vms/ADSREngine.c
@@ -332,9 +332,7 @@ void VMS_addBlockToList(VMS_BLOCK * block, SynthVoice * voice){
     data->targetVoice = voice;
     data->period = block->period;
     data->nextRunTime = SYS_getTime();
-    
-    int32_t param1 = VMS_getParam(block, voice, 1);
-    
+
     switch(block->type){
         case VMS_SIN:
             data->data = pvPortMalloc(sizeof(SINE_DATA));


### PR DESCRIPTION
* add `test` command back in
* make check for unclosed quotes actually work
* fix type conversion warnings
* add in missing return in `TERM_countArgs` and `TERM_seperateArgs`
* remove unused code from vms