### PR TITLE
Burst mode fixes

### DIFF
--- a/common/ud3core/interrupter.c
+++ b/common/ud3core/interrupter.c
@@ -462,47 +462,29 @@ void vBurst_Timer_Callback(TimerHandle_t xTimer){
 ******************************************************************************/
 uint8_t callback_BurstFunction(parameter_entry * params, uint8_t index, TERMINAL_HANDLE * handle) {
     if(interrupter.mode!=INTR_MODE_OFF){
-        if(interrupter.xBurst_Timer==NULL && param.burst_on > 0){
+        if(interrupter.xBurst_Timer==NULL && param.burst_off > 0){
             interrupter.burst_state = BURST_ON;
             interrupter.xBurst_Timer = xTimerCreate("Bust-Tmr", param.burst_on / portTICK_PERIOD_MS, pdFALSE,(void * ) 0, vBurst_Timer_Callback);
             if(interrupter.xBurst_Timer != NULL){
                 xTimerStart(interrupter.xBurst_Timer, 0);
                 ttprintf("Burst Enabled\r\n");
-                interrupter.mode=INTR_MODE_BURST;
+                interrupter.mode=INTR_MODE_TR;
             }else{
                 interrupter.pw = 0;
                 ttprintf("Cannot create burst Timer\r\n");
                 interrupter.mode=INTR_MODE_OFF;
             }
-        }else if(interrupter.xBurst_Timer!=NULL && !param.burst_on){
-            if (interrupter.xBurst_Timer != NULL) {
-    			if(xTimerDelete(interrupter.xBurst_Timer, 200 / portTICK_PERIOD_MS) != pdFALSE){
-    			    interrupter.xBurst_Timer = NULL;
-                    interrupter.burst_state = BURST_ON;
-                    interrupter.pw =0;
-                    update_interrupter();
-                    interrupter.mode=INTR_MODE_TR;
-                    ttprintf("\r\nBurst Disabled\r\n");
-                }else{
-                    ttprintf("Cannot delete burst Timer\r\n");
-                    interrupter.burst_state = BURST_ON;
-                }
-            }
         }else if(interrupter.xBurst_Timer!=NULL && !param.burst_off){
-            if (interrupter.xBurst_Timer != NULL) {
-    			if(xTimerDelete(interrupter.xBurst_Timer, 200 / portTICK_PERIOD_MS) != pdFALSE){
-    			    interrupter.xBurst_Timer = NULL;
-                    interrupter.burst_state = BURST_ON;
-                    interrupter.pw =param.pw;
-                    update_interrupter();
-                    interrupter.mode=INTR_MODE_TR;
-                    ttprintf("\r\nBurst Disabled\r\n");
-                }else{
-                    ttprintf("Cannot delete burst Timer\r\n");
-                    interrupter.burst_state = BURST_ON;
-                }
+            if(xTimerDelete(interrupter.xBurst_Timer, 200 / portTICK_PERIOD_MS) != pdFALSE){
+                interrupter.xBurst_Timer = NULL;
+                interrupter.burst_state = BURST_ON;
+                update_interrupter();
+                interrupter.mode=INTR_MODE_TR;
+                ttprintf("\r\nBurst Disabled\r\n");
+            }else{
+                ttprintf("Cannot delete burst Timer\r\n");
+                interrupter.burst_state = BURST_ON;
             }
-
         }
     }
 	return pdPASS;

--- a/common/ud3core/interrupter.h
+++ b/common/ud3core/interrupter.h
@@ -54,7 +54,6 @@ enum interrupter_DMA{
 enum interrupter_mode{
     INTR_MODE_OFF=0,
     INTR_MODE_TR,
-    INTR_MODE_BURST,
     INTR_MODE_BLOCKED
 };
 


### PR DESCRIPTION
Fixed bugs:
- In some cases burst mode would not accept pw/pwd changes
- Behavior was quite inconsistent with bon=0, depending on how that state was reached it could mean no output at all or full output. Now burst mode is enabled if and only if boff>0.

There is one problem with the second change: Teslaterm builds before https://github.com/malte0811/Teslaterm/commit/7c13bc2f5aeb44b1fae6ae6c1edc7851fc25bf8b start with bon=0, boff=500, which now means no output at all. I don't see a good solution for this: the current behavior is quite eratic and IMO needs to be changed, but leaving a special case for "old" TT builds would be quite messy.  
For the future it might be an option to send some sort of "protocol"/"compatibility" version as part of the feature packet, and to have TT show a warning when a too recent UD3 build is used; but that does not help in the current case.