### PR TITLE
Audio output for simulator

### DIFF
--- a/common/ud3core/cli_common.c
+++ b/common/ud3core/cli_common.c
@@ -521,10 +521,10 @@ uint8_t con_minstat(TERMINAL_HANDLE * handle){
         ttprintf("%sSequence mismatch drop: %lu\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),min_ctx.transport_fifo.sequence_mismatch_drop);
         ttprintf("%sMax frames in buffer  : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),min_ctx.transport_fifo.n_frames_max);
         ttprintf("%sCRC errors            : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),min_ctx.transport_fifo.crc_fails);
-        ttprintf("%sRemote Time           : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),time.remote);
+        ttprintf("%sRemote Time           : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),min_time.remote);
         ttprintf("%sLocal Time            : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),l_time);
-        ttprintf("%sDiff Time             : %i\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),time.diff);
-        ttprintf("%sResync count          : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),time.resync);
+        ttprintf("%sDiff Time             : %i\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),min_time.diff);
+        ttprintf("%sResync count          : %u\r\n", TERM_getVT100Code(_VT100_ERASE_LINE_END, 0),min_time.resync);
     }
     TERM_sendVT100Code(handle, _VT100_CURSOR_ENABLE,0);
     return 1; 

--- a/common/ud3core/interrupter.h
+++ b/common/ud3core/interrupter.h
@@ -80,7 +80,11 @@ typedef struct
 
 interrupter_params interrupter;
 
-extern uint16 ch_prd[4], ch_cmp[4];
+extern uint16_t ch_prd[4], ch_cmp[4];
+// These are only exposed for use in the simulator, do not use in actual UD3 code!
+extern uint16_t int1_prd, int1_cmp;
+extern uint8_t int1_dma_Chan;
+extern uint8_t ch_dma_Chan[N_CHANNEL];
 
 void initialize_interrupter(void);
 void configure_interrupter();

--- a/common/ud3core/tasks/tsk_min.c
+++ b/common/ud3core/tasks/tsk_min.c
@@ -69,7 +69,7 @@ SemaphoreHandle_t min_Semaphore;
 #include "helper/printf.h" 
 
 struct min_context min_ctx;
-struct _time time;
+struct _time min_time;
 
 uint32_t uart_bytes_rx=0;
 uint32_t uart_bytes_tx=0;
@@ -147,15 +147,15 @@ void min_tx_finished(uint8_t port){
 	#endif
 }
 void time_cb(uint32_t remote_time){
-    time.remote = remote_time;
-    time.diff_raw = time.remote-l_time;
-    time.diff = average(&sample,time.diff_raw);
-    if(time.diff>1000 ||time.diff<-1000){
-        clock_set(time.remote);
-        time.resync++;   
+    min_time.remote = remote_time;
+    min_time.diff_raw = min_time.remote-l_time;
+    min_time.diff = average(&sample,min_time.diff_raw);
+    if(min_time.diff>1000 ||min_time.diff<-1000){
+        clock_set(min_time.remote);
+        min_time.resync++;
         //clock_reset_inc();
     }else{
-        clock_trim(time.diff);
+        clock_trim(min_time.diff);
     }   
 }
 
@@ -444,8 +444,8 @@ void min_application_handler(uint8_t min_id, uint8_t *min_payload, uint8_t len_p
         case MIN_ID_WD:
                 if(len_payload==4){
                     int32_t ind = 0;
-                    time.remote = buffer_get_uint32(min_payload, &ind);
-                    time_cb(time.remote);
+                    min_time.remote = buffer_get_uint32(min_payload, &ind);
+                    time_cb(min_time.remote);
                 }
                 WD_reset();
             return;

--- a/common/ud3core/tasks/tsk_min.h
+++ b/common/ud3core/tasks/tsk_min.h
@@ -63,7 +63,7 @@ void MIN_print(void * port, char * format, ...);
 void tsk_min_Start(void);
 void min_reset_flow(void);
 extern struct _socket_info socket_info[NUM_MIN_CON];
-extern struct _time time;
+extern struct _time min_time;
 extern uint32_t uart_bytes_rx;
 extern uint32_t uart_bytes_tx;
 /*

--- a/common/vms/ADSREngine.c
+++ b/common/vms/ADSREngine.c
@@ -354,7 +354,8 @@ void VMS_nextBlock(VMS_listDataObject * data, unsigned blockSet){
             if(block->nextBlocks[c] == VMS_DIE){
                 return;
             }
-            if(ptr_is_in_ram(block->nextBlocks[c]) || ptr_is_in_flash(block->nextBlocks[c])) VMS_addBlockToList(block->nextBlocks[c], voice);
+            if(block->nextBlocks[c])
+                VMS_addBlockToList(block->nextBlocks[c], voice);
         }
     }else{
         if(block->offBlock != 0){

--- a/simulator/console.c
+++ b/simulator/console.c
@@ -33,6 +33,7 @@
 
 #include <FreeRTOS.h>
 #include <semphr.h>
+#include <stdlib.h>
 
 SemaphoreHandle_t xStdioMutex;
 StaticSemaphore_t xStdioMutexBuffer;
@@ -40,7 +41,7 @@ StaticSemaphore_t xStdioMutexBuffer;
 void console_init(void)
 {
     xStdioMutex = xSemaphoreCreateMutex();
-	system("stty -echo");
+	system("stty -echo erase ''");
 }
 
 void console_print(const char *fmt, ...)

--- a/simulator/main.c
+++ b/simulator/main.c
@@ -84,6 +84,7 @@
 #include "tasks/tsk_hwGauge.h"
 #include "tasks/tsk_duty.h"
 #include "tsk_sim.h"
+#include "tsk_audio.h"
 
 
 /*
@@ -203,7 +204,8 @@ int main( void )
 	
 	console_print("Simulation init...\n");
 	tsk_sim_Start();
-    
+	tsk_audio_Start();
+
     //CyGlobalIntEnable; //enables interrupts
     alarm_push(ALM_PRIO_INFO, "UD3 started", ALM_NO_VALUE);
 	

--- a/simulator/sim_hw.c
+++ b/simulator/sim_hw.c
@@ -99,38 +99,42 @@ void LED4_Write(uint8_t val){
 	led[3]=val;
 }
 
-uint8_t DDS32_1_en[2];
-uint32_t DDS32_1_freq[2];
+uint8_t DDS32_en[4] = {};
+uint32_t DDS32_freq[4] = {};
 void DDS32_1_Enable_ch(uint8_t ch){
-	DDS32_1_en[ch]=1;
+	DDS32_en[ch]=1;
 }
 void DDS32_1_Disable_ch(uint8_t ch){
-	DDS32_1_en[ch]=0;
+	DDS32_en[ch]=0;
 }
-uint8_t DDS32_2_en[2];
-uint32_t DDS32_2_freq[2];
 void DDS32_2_Enable_ch(uint8_t ch){
-	DDS32_2_en[ch]=1;
+	DDS32_en[2+ch]=1;
 }
 void DDS32_2_Disable_ch(uint8_t ch){
-	DDS32_2_en[ch]=0;
+	DDS32_en[2+ch]=0;
 }
 
 uint32_t DDS32_1_SetFrequency_FP8(uint8_t ch,uint32_t freq){
-	DDS32_1_freq[ch]=freq;
+	DDS32_freq[ch]=freq;
 	return freq>>8;
 }
 uint32_t DDS32_2_SetFrequency_FP8(uint8_t ch,uint32_t freq){
-	DDS32_2_freq[ch]=freq;
+	DDS32_freq[2+ch]=freq;
 	return freq>>8;
 }
+
+uint32_t DDS32_noise[4] = {};
 void DDS32_1_WriteRand0(uint32_t rnd){
+    DDS32_noise[0] = rnd;
 }
 void DDS32_1_WriteRand1(uint32_t rnd){
+    DDS32_noise[1] = rnd;
 }
 void DDS32_2_WriteRand0(uint32_t rnd){
+    DDS32_noise[2] = rnd;
 }
 void DDS32_2_WriteRand1(uint32_t rnd){
+    DDS32_noise[3] = rnd;
 }
 
 

--- a/simulator/sim_hw.h
+++ b/simulator/sim_hw.h
@@ -170,12 +170,15 @@ typedef uint16_t uint16;
 extern uint8_t IVO_UART_Control;
 
 
+extern uint8_t DDS32_en[4];
 void DDS32_1_Enable_ch(uint8_t ch);
 void DDS32_2_Enable_ch(uint8_t ch);
+extern uint32_t DDS32_freq[4];
 void DDS32_1_Disable_ch(uint8_t ch);
 void DDS32_2_Disable_ch(uint8_t ch);
 uint32_t DDS32_1_SetFrequency_FP8(uint8_t ch,uint32_t freq);
 uint32_t DDS32_2_SetFrequency_FP8(uint8_t ch,uint32_t freq);
+extern uint32_t DDS32_noise[4];
 void DDS32_1_WriteRand0(uint32_t rnd);
 void DDS32_1_WriteRand1(uint32_t rnd);
 void DDS32_2_WriteRand0(uint32_t rnd);

--- a/simulator/tsk_audio.c
+++ b/simulator/tsk_audio.c
@@ -1,0 +1,128 @@
+#include "tsk_audio.h"
+
+
+#include "FreeRTOS.h"
+#include "SignalGeneratorSID.h"
+#include "qcw.h"
+#include "task.h"
+#include "queue.h"
+#include "console.h"
+
+#include "tasks/tsk_analog.h"
+#include "semphr.h"
+#include "telemetry.h"
+#include "interrupter.h"
+#include "cli_common.h"
+#include "cli_basic.h"
+#include "clock.h"
+#include "SignalGenerator.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <errno.h>
+
+const int audio_rate = 44100;
+const int interrupter_clock = 1000000;
+const int pwm_counts_per_sample = interrupter_clock / audio_rate;
+
+bool is_active(size_t old_inter, size_t new_inter, int prd) {
+    return new_inter / prd > old_inter / prd;
+}
+
+int get_tr_volume(size_t old_inter, size_t new_inter) {
+    if (!(interrupter1_control_Control & 2)) {
+        return 0;
+    } else {
+        return (1 << 12) * is_active(old_inter, new_inter, int1_prd);
+    }
+}
+
+bool add_volume(
+    size_t pwm_counter, int16_t* audio_buffer, size_t buffer_size, size_t prd, int16_t pw, bool noise
+) {
+    int volume = (1 << 14) * pw / configuration.max_tr_pw;
+    size_t prd_buffer = prd / pwm_counts_per_sample;
+    size_t offset = (prd - pwm_counter % prd) / pwm_counts_per_sample;
+    int num_changed = 0;
+    for (size_t i = offset; i < buffer_size; i += prd_buffer) {
+        size_t index_to_increase = i;
+        if (noise) {
+            size_t noise_range = prd_buffer / 2;
+            size_t noise = rand() % noise_range;
+            index_to_increase += noise;
+            if (index_to_increase >= buffer_size) {
+                index_to_increase = buffer_size - 1;
+            }
+        }
+        audio_buffer[index_to_increase] += volume;
+        ++num_changed;
+    }
+    return num_changed > 0;
+}
+
+// If TR is briefly turned on (e.g. burst mode) at low frequencies, we want to play at least one cycle, even if that
+// falls outside the window where TR was enabled
+bool force_tr_next_cycle = false;
+
+void add_tr_volume(size_t pwm_counter, int16_t* audio_buffer, size_t samples_in_batch) {
+    if (force_tr_next_cycle || (interrupter1_control_Control & 2)) {
+        force_tr_next_cycle = !add_volume(
+            pwm_counter, audio_buffer, samples_in_batch, int1_prd, int1_prd - int1_cmp, false
+        );
+    }
+}
+
+void add_total_dds_volume(size_t pwm_counter, int16_t* audio_buffer, size_t buffer_size) {
+    for (int channel = 0; channel < 4; ++channel) {
+        if (DDS32_en[channel]) {
+            int prd = interrupter_clock / (DDS32_freq[channel] >> 8);
+            int pw = ch_prd[channel] - ch_cmp[channel];
+            add_volume(pwm_counter, audio_buffer, buffer_size, prd, pw,  DDS32_noise[channel] != 0);
+        }
+    }
+}
+
+void tsk_audio(void *pvParameters) {
+    FILE* audio_pipe = popen("aplay --rate=44100 --format=S16_LE", "w");
+    const int batches_per_second = 50;
+    const int ms_per_audio_batch = 1000 / batches_per_second;
+    const TickType_t batch_delay = ms_per_audio_batch / portTICK_PERIOD_MS;
+
+    const int ns_per_sample = 1e9 / audio_rate;
+    size_t pwm_counter = 0;
+    int next_channel = 0;
+    struct timespec last_time;
+    clock_gettime(CLOCK_REALTIME, &last_time);
+    int16_t* audio_buffer = NULL;
+    while(1){
+        vTaskDelay(batch_delay);
+
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        // Keep ahead by 10 ms
+        now.tv_nsec += 10e6;
+        const size_t ns_between = 1e9 * (now.tv_sec - last_time.tv_sec) + now.tv_nsec - last_time.tv_nsec;
+        const int samples_in_batch = ns_between / ns_per_sample;
+        last_time = now;
+
+        size_t buffer_bytes = sizeof(*audio_buffer) * samples_in_batch;
+        audio_buffer = realloc(audio_buffer, buffer_bytes);
+        memset(audio_buffer, 0, buffer_bytes);
+        add_tr_volume(pwm_counter, audio_buffer, samples_in_batch);
+        add_total_dds_volume(pwm_counter, audio_buffer, samples_in_batch);
+        pwm_counter += pwm_counts_per_sample * samples_in_batch;
+        fwrite(audio_buffer, sizeof(*audio_buffer), samples_in_batch, audio_pipe);
+        fflush(audio_pipe);
+    }
+}
+
+xTaskHandle tsk_audio_TaskHandle;
+
+void tsk_audio_Start() {
+    char const* audio_enabled = getenv("ud3sim_audio");
+    if (audio_enabled && *audio_enabled == '1') {
+        console_print("Audio init...\n");
+        xTaskCreate(tsk_audio, "AUDIO", 1024, NULL, 3, &tsk_audio_TaskHandle);
+    }
+}

--- a/simulator/tsk_audio.h
+++ b/simulator/tsk_audio.h
@@ -1,0 +1,6 @@
+#ifndef tsk_audio_H
+#define tsk_audio_H
+
+void tsk_audio_Start();
+
+#endif


### PR DESCRIPTION
Audio is disabled by default, start the simulator as `ud3sim_audio=1 build/ud3sim` to enable it. I don't know how well it works under WSL, can someone else (who has actually got WSL set up) test that?